### PR TITLE
Fix issue: parsing breaks if chunk ends in middle of CDATA or markup …

### DIFF
--- a/lib/Saxophone.js
+++ b/lib/Saxophone.js
@@ -108,6 +108,7 @@ const Node = {
     text: 'text',
     cdata: 'cdata',
     comment: 'comment',
+    markupDeclaration: 'markupDeclaration',
     processingInstruction: 'processinginstruction',
     tagOpen: 'tagopen',
     tagClose: 'tagclose',
@@ -236,9 +237,19 @@ class Saxophone extends Writable {
                 chunkPos += 1;
                 const nextNextChar = input[chunkPos];
 
+                // Unclosed markup declaration section of unknown type,
+                // we need to wait for upcoming data
+                if (nextNextChar === undefined) {
+                    this._stall(
+                        Node.markupDeclaration,
+                        input.slice(chunkPos - 2)
+                    );
+                    break;
+                }
+
                 if (
                     nextNextChar === '[' &&
-                    input.slice(chunkPos + 1, chunkPos + 7) === 'CDATA['
+                    'CDATA['.indexOf(input.slice(chunkPos + 1, chunkPos + 7)) > -1
                 ) {
                     chunkPos += 7;
                     const cdataClose = input.indexOf(']]>', chunkPos);


### PR DESCRIPTION
…definiton tag name

While parsing a large XML file with a lot of CDATA sections, I noticed that the parser breaks if the chunk happens to end in the middle of the starting tag (i. e. the end of chunk looks like <![CDA or <![ or <! etc.). This commit resolves these cases, along with any other similar ones that could occure in case of markup declaration tags.